### PR TITLE
Update install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -28,7 +28,7 @@ if (-not $version) {
   $latest_release_uri =
     "https://api.github.com/repos/khanhas/spicetify-cli/releases/latest"
   Write-Part "DOWNLOADING    "; Write-Emphasized $latest_release_uri
-  $latest_release_json = Invoke-WebRequest -Uri $latest_release_uri
+  $latest_release_json = Invoke-WebRequest -Uri $latest_release_uri -UseBasicParsing
   Write-Done
 
   $version = ($latest_release_json | ConvertFrom-Json).tag_name -replace "v", ""
@@ -47,7 +47,7 @@ $zip_file = "${sp_dir}\spicetify-${version}-windows-x64.zip"
 $download_uri = "https://github.com/khanhas/spicetify-cli/releases/download/" +
                 "v${version}/spicetify-${version}-windows-x64.zip"
 Write-Part "DOWNLOADING    "; Write-Emphasized $download_uri
-Invoke-WebRequest -Uri $download_uri -OutFile $zip_file
+Invoke-WebRequest -Uri $download_uri -UseBasicParsing -OutFile $zip_file
 Write-Done
 
 # Extract spicetify.exe and assets from .zip file.


### PR DESCRIPTION
Adding the parameter -UseBasicParsing to Invoke-WebRequest fixes the error appearing when
Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete.